### PR TITLE
Disabled SSL peer verification in HTTPSocket

### DIFF
--- a/includes/lib/Domain.php
+++ b/includes/lib/Domain.php
@@ -46,12 +46,12 @@ class Domain {
      */
     private function getSocket() {
         if (!$this->socket) {
-            $address = '127.0.0.1';
-            $address = (isset($_SERVER['SSL']) && $_SERVER['SSL'] == "1") ? 'ssl://' . $address : $address;
+            $address = (isset($_SERVER['SSL']) && $_SERVER['SSL'] == "1") ? 'ssl://127.0.0.1' : '127.0.0.1';
+            $username = ($this->account && $this->account->getUsername() != 'admin') ? 'admin|' . $this->account->getUsername() : 'admin';
 
             $this->socket = new HTTPSocket();
             $this->socket->connect($address, 2222);
-            $this->socket->set_login('admin');
+            $this->socket->set_login($username);
         }
 
         return $this->socket;

--- a/includes/lib/Domain.php
+++ b/includes/lib/Domain.php
@@ -47,11 +47,10 @@ class Domain {
     private function getSocket() {
         if (!$this->socket) {
             $address = (isset($_SERVER['SSL']) && $_SERVER['SSL'] == "1") ? 'ssl://127.0.0.1' : '127.0.0.1';
-            $username = ($this->account && $this->account->getUsername() != 'admin') ? 'admin|' . $this->account->getUsername() : 'admin';
 
             $this->socket = new HTTPSocket();
             $this->socket->connect($address, 2222);
-            $this->socket->set_login($username);
+            $this->socket->set_login('admin');
         }
 
         return $this->socket;

--- a/includes/lib/HTTPSocket.php
+++ b/includes/lib/HTTPSocket.php
@@ -189,7 +189,13 @@ class HTTPSocket {
         }
         else
         {
-            $socket = @fsockopen( $this->remote_host, $this->remote_port, $sock_errno, $sock_errstr, 10 );
+            $context = stream_context_create(array(
+                'ssl' => array(
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                )
+            ));
+            $socket = stream_socket_client( $this->remote_host . ':' . $this->remote_port, $sock_errno, $sock_errstr, 10, STREAM_CLIENT_CONNECT, $context );
         }
 
         if ( !$socket || !$OK )


### PR DESCRIPTION
Disabled SSL peer verification in HTTPSocket (necessary for self-signed certificate on 127.0.0.1), ~~also modified username for every domain that isn't owned by the admin~~
