### PR TITLE
Verify $result['list'] exists

### DIFF
--- a/includes/lib/Domain.php
+++ b/includes/lib/Domain.php
@@ -256,9 +256,11 @@ class Domain {
 
             $subdomains = ['www.' . $this->getDomain()];
 
-            foreach ($result['list'] as $subdomain) {
-                $subdomains[] = $subdomain . '.' . $this->getDomain();
-                $subdomains[] = 'www.' . $subdomain . '.' . $this->getDomain();
+            if (isset($result['list'])) {
+                foreach ($result['list'] as $subdomain) {
+                    $subdomains[] = $subdomain . '.' . $this->getDomain();
+                    $subdomains[] = 'www.' . $subdomain . '.' . $this->getDomain();
+                }
             }
         }
 


### PR DESCRIPTION
When subdomain list is empty, this doesn't exist and gives a warning.
