### PR TITLE
Catch exception for more information

### DIFF
--- a/includes/lib/Account.php
+++ b/includes/lib/Account.php
@@ -117,7 +117,11 @@ class Account {
      * @throws \Kelunik\Acme\AcmeException
      */
     public function register() {
-        $this->acme->register($this->email);
+        try {
+            $this->acme->register($this->email);
+        } catch (\Exception $e) {
+            throw new \Exception('Error registering ' . $this->email . ': '. $e->getMessage(), $e->getCode(), $e);
+        }
 
         $this->config('status', 'registered at Let\'s Encrypt');
         $this->config('email', $this->email);

--- a/includes/lib/Challenges.php
+++ b/includes/lib/Challenges.php
@@ -111,7 +111,12 @@ class Challenges {
             $challenge = $this->challenges[$domain][reset($this->solvableChallenges[$domain])];
 
             if ($challenge->solvable()) {
-                $challenge->solve();
+                try {
+                    $challenge->solve();
+                } catch (\Exception $e) {
+                    throw new \Exception('Exception while solving challenge for ' . $domain
+                        . ': ' .$e->getMessage(), $e->getCode(), $e);
+                }
             } else {
                 throw new \Exception('Defined unsolvable challenge for ' . $domain);
             }

--- a/includes/lib/Domain.php
+++ b/includes/lib/Domain.php
@@ -102,8 +102,12 @@ class Domain {
             $domains = array_merge($domains, $subdomains);
         }
 
-        $location = $this->account->acme->requestCertificate($domainKeys, $domains);
-        $this->certificates = $this->account->acme->pollForCertificate($location);
+        try {
+            $location = $this->account->acme->requestCertificate($domainKeys, $domains);
+            $this->certificates = $this->account->acme->pollForCertificate($location);
+        } catch (\Exception $e) {
+            throw new \Exception("Error requesting certificate: ". $e->getMessage(), $e->getCode(), $e);
+        }
 
         return $this->certificates;
     }


### PR DESCRIPTION
Show which domain is failing, for example when DNS cannot be resolved. This way, it's more obvious where the problem lies.
