### PR TITLE
Set expiration to 90 days

### DIFF
--- a/user/actions/request.html
+++ b/user/actions/request.html
@@ -90,7 +90,7 @@ try {
     $domain->config('subdomains', $_POST['subdomains']);
 
     $domain->config('status', 'applied to DirectAdmin');
-    $domain->config('expire', date('Y-m-d', strtotime('+50 days')));
+    $domain->config('expire', date('Y-m-d', strtotime('+90 days')));
 
     if (!in_array($domain->getDomain(), (array) $account->config('domains'))) {
         $account->config('domains', ((array) $account->config('domains')) + [$domain->getDomain()]);


### PR DESCRIPTION
Expiration is 90 days currently; https://letsencrypt.org/2015/11/09/why-90-days.html

Renewal is advised every 60 days, but the information should be correct. If we want to renew early (50 or 60 days), that should be handled at the cron level (imho).

Isn't it possible to actually get the real expiration date? In case it changes?
